### PR TITLE
NamingServer done

### DIFF
--- a/NameServer/src/main/java/nintendods/ds_project/Exeptions/NameServerFullExeption.java
+++ b/NameServer/src/main/java/nintendods/ds_project/Exeptions/NameServerFullExeption.java
@@ -1,0 +1,7 @@
+package nintendods.ds_project.Exeptions;
+
+public class NameServerFullExeption extends Exception{
+    public NameServerFullExeption(){
+        super("NameServer is full");
+    }
+}

--- a/NameServer/src/main/java/nintendods/ds_project/helper/Mapping.java
+++ b/NameServer/src/main/java/nintendods/ds_project/helper/Mapping.java
@@ -17,16 +17,16 @@ public class Mapping {
      */
     public static int map(double x, double inMin, double inMax, double outMin, double outMax) {
 
-        if(x < inMin)
+        if(x <= inMin)
             return (int) outMin;
 
-        if(x > inMax)
+        if(x >= inMax)
             return (int) outMax;
 
         if((inMax - inMin) == 0){
             return 0;
         }
 
-        return (int) (((x - inMin) * (outMax - outMin)) / ((inMax - inMin) + outMin));
+        return (int) Math.round(((x - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin); // if you do double -> int, then the numbers behind the comma get cut of. So 1.9 becomes 1, which means that getting outMax is nearly impossible unless x=inMax
     }
 }

--- a/NameServer/src/main/java/nintendods/ds_project/model/NameServerDatabase.java
+++ b/NameServer/src/main/java/nintendods/ds_project/model/NameServerDatabase.java
@@ -1,4 +1,5 @@
 package nintendods.ds_project.model;
+import nintendods.ds_project.Exeptions.NameServerFullExeption;
 import nintendods.ds_project.helper.NameToHash;
 
 import java.net.InetAddress;
@@ -7,23 +8,74 @@ import java.util.*;
 
 public class NameServerDatabase {
 
-    private TreeMap<Integer, InetAddress> nodeID_to_nodeIP = new TreeMap<>();
+    public NameServerDatabase() {
+        nodeID_to_nodeIP = new TreeMap<>();
+    }
 
-    public Integer addNode(String name, InetAddress inetAddress){
+    private final TreeMap<Integer, InetAddress> nodeID_to_nodeIP;
+
+    /**
+     * <p>Add a server to the list.</p>
+     *
+     * <p>Since the ID is based on name, it's possible that 2 different names have the same Hash.
+     * To not override a name that has come before we will move the new ID by 1 until it finds an empty spot.</p>
+     *
+     * <p>If it can't find an empty spot NameServerFullExeption is thrown.</p>
+     *
+     * @param name
+     * @param inetAddress
+     * @return ID of server
+     * @throws NameServerFullExeption
+     */
+    public Integer addNode(String name, InetAddress inetAddress) throws NameServerFullExeption {
         Integer nodeID = NameToHash.convert(name);
-        nodeID_to_nodeIP.put(nodeID, inetAddress);
-        return nodeID;
+
+        for (int i = 0; i < 32768; ++i) {
+            if (!nodeID_to_nodeIP.containsKey(nodeID)) {
+                nodeID_to_nodeIP.put(nodeID, inetAddress);
+                return nodeID;
+            }
+
+            nodeID++;
+            if (nodeID > 32768){
+                nodeID = 0;
+            }
+        }
+
+        throw new NameServerFullExeption();
+    }
+
+    public void deleteNode(InetAddress inetAddress){
+        nodeID_to_nodeIP.entrySet().removeIf(entry -> entry.getValue().equals(inetAddress));
     }
 
     public InetAddress getNodeIPfromID(Integer nodeID){
         return nodeID_to_nodeIP.get(nodeID);
     }
 
-    public InetAddress getNodeIPfromName(String name){
-        return getNodeIPfromID(getNodeID(name));
+    /**
+     * Retrieves the closest IP address of the server with the hash closest to the given file name.
+     * <p> <b>WARNING! Just because you input the exact name of a server doesn't mean you will definitely get its IP back! </b></p>
+     *
+     * <p>See {@link #addNode(String, InetAddress)} to learn on how servers are added and how their hashes are determined,
+     * which causes the warning.</p>
+     *  @param name file name
+     * @return ipp of server for the file
+     */
+    public InetAddress getClosestNodeIP(String name){
+        return getNodeIPfromID(getClosestNodeID(name));
     }
 
-    public int getNodeID(String name){
+    /**
+     * Retrieves the closest ID address of the server with the hash closest to the given file name.
+     * <p> <b>WARNING! Just because you input the exact name of a server doesn't mean you will definitely get its ID back! </b></p>
+     *
+     * <p>See {@link #addNode(String, InetAddress)} to learn on how servers are added and how their hashes are determined,
+     * which causes the warning.</p>
+     *  @param name file name
+     * @return ID of server for the file
+     */
+    public int getClosestNodeID(String name){
         Integer tempID = NameToHash.convert(name);
 
         Integer floor = nodeID_to_nodeIP.floorKey(tempID);

--- a/NameServer/src/test/java/nintendods/ds_project/helper/NameToHashTests.java
+++ b/NameServer/src/test/java/nintendods/ds_project/helper/NameToHashTests.java
@@ -15,7 +15,7 @@ public class NameToHashTests {
         // We know the algo for the String.hashCode().
         // the value "" = 0
         // Algo is s[0]*31^(n-1) with s[0] = 0 and n = 1 so 0*38^0 = 0
-        String checkString1 = "jeff";
+        String checkString1 = "";
 
         int id1 = NameToHash.convert(checkString1);
 

--- a/NameServer/src/test/java/nintendods/ds_project/model/NameServerDatabaseTests.java
+++ b/NameServer/src/test/java/nintendods/ds_project/model/NameServerDatabaseTests.java
@@ -1,19 +1,24 @@
 package nintendods.ds_project.model;
 
+import nintendods.ds_project.Exeptions.NameServerFullExeption;
+import nintendods.ds_project.helper.Mapping;
 import nintendods.ds_project.helper.NameToHash;
 import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Random;
+import java.util.TreeMap;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 public class NameServerDatabaseTests {
 
     @Test
-    public void getNodeIDTest_BasicClosest() throws UnknownHostException {
+    public void getNodeIDTest_BasicClosest() throws Exception {
         NameServerDatabase nameServerDatabase = new NameServerDatabase();
 
         InetAddress address1 = InetAddress.getByName("10.10.10.10");
@@ -25,12 +30,12 @@ public class NameServerDatabaseTests {
         nameServerDatabase.addNode(createStringWithKnownHash(32000), address2);
         nameServerDatabase.addNode(createStringWithKnownHash(15), address3);
 
-        assertEquals(nameServerDatabase.getNodeID(createStringWithKnownHash(12)), 10);
-        assertEquals(nameServerDatabase.getNodeIPfromName(createStringWithKnownHash(12)), address1);
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(12)), 10);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(12)), address1);
     }
 
     @Test
-    public void getNodeIDTest_WrapFromTop() throws UnknownHostException {
+    public void getNodeIDTest_WrapFromTop() throws Exception {
         NameServerDatabase nameServerDatabase = new NameServerDatabase();
 
         InetAddress address1 = InetAddress.getByName("10.10.10.10");
@@ -42,12 +47,12 @@ public class NameServerDatabaseTests {
         nameServerDatabase.addNode(createStringWithKnownHash(32000), address2);
         nameServerDatabase.addNode(createStringWithKnownHash(15), address3);
 
-        assertEquals(nameServerDatabase.getNodeID(createStringWithKnownHash(32760)), 10);
-        assertEquals(nameServerDatabase.getNodeIPfromName(createStringWithKnownHash(32760)), address1);
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(32760)), 10);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(32760)), address1);
     }
 
     @Test
-    public void getNodeIDTest_WrapFromBottom() throws UnknownHostException {
+    public void getNodeIDTest_WrapFromBottom() throws Exception {
         NameServerDatabase nameServerDatabase = new NameServerDatabase();
 
         InetAddress address1 = InetAddress.getByName("10.10.10.10");
@@ -59,12 +64,12 @@ public class NameServerDatabaseTests {
         nameServerDatabase.addNode(createStringWithKnownHash(32000), address2);
         nameServerDatabase.addNode(createStringWithKnownHash(15000), address3);
 
-        assertEquals(nameServerDatabase.getNodeID(createStringWithKnownHash(100)), 32000);
-        assertEquals(nameServerDatabase.getNodeIPfromName(createStringWithKnownHash(100)), address2);
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(100)), 32000);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(100)), address2);
     }
 
     @Test
-    public void getNodeIDTest_ExactMatch() throws UnknownHostException {
+    public void getNodeIDTest_ExactMatch() throws Exception {
         NameServerDatabase nameServerDatabase = new NameServerDatabase();
 
         InetAddress address1 = InetAddress.getByName("10.10.10.10");
@@ -76,10 +81,85 @@ public class NameServerDatabaseTests {
         nameServerDatabase.addNode(createStringWithKnownHash(32000), address2);
         nameServerDatabase.addNode(createStringWithKnownHash(15000), address3);
 
-        assertEquals(nameServerDatabase.getNodeID(createStringWithKnownHash(32000)), 32000);
-        assertEquals(nameServerDatabase.getNodeIPfromName(createStringWithKnownHash(100)), address2);
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(32000)), 32000);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(100)), address2);
     }
 
+    @Test
+    public void getNodeIDTest_SameHash() throws Exception {
+        NameServerDatabase nameServerDatabase = new NameServerDatabase();
+
+        InetAddress address1 = InetAddress.getByName("10.10.10.10");
+        InetAddress address2 = InetAddress.getByName("10.10.10.11");
+        InetAddress address3 = InetAddress.getByName("10.10.10.12");
+
+
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(10000), address1));
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(10000), address2));
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(10000), address3));
+
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(32000)), 10000);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(32000)), address1);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(10001)), address2);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(11000)), address3);
+    }
+
+    @Test
+    public void getNodeIDTest_SameHash_IDbackTo0() throws Exception {
+        NameServerDatabase nameServerDatabase = new NameServerDatabase();
+
+        InetAddress address1 = InetAddress.getByName("10.10.10.10");
+        InetAddress address2 = InetAddress.getByName("10.10.10.11");
+        InetAddress address3 = InetAddress.getByName("10.10.10.12");
+
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(32768), address1));
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(32768), address2));
+        System.out.println(nameServerDatabase.addNode(createStringWithKnownHash(32768), address3));
+
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(32000)), 32768);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(32000)), address1);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(0)), address2);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(1)), address3);
+    }
+
+    @Test(expected = NameServerFullExeption.class)
+    public void getNodeIDTest_SameHash_FullServer() throws Exception {
+        NameServerDatabase nameServerDatabase = new NameServerDatabase();
+        InetAddress address = InetAddress.getByName("10.10.10.10");
+
+        // had to fill in the map directly because any other means would be really, really slow
+        Field mapField = NameServerDatabase.class.getDeclaredField("nodeID_to_nodeIP");
+        mapField.setAccessible(true);
+        TreeMap<Integer, InetAddress> nodeID_to_nodeIP = (TreeMap<Integer, InetAddress>) mapField.get(nameServerDatabase);
+        for (int i = 0; i <= 32768; i++) {
+            nodeID_to_nodeIP.put(i, address);
+        }
+        mapField.setAccessible(false);
+
+        nameServerDatabase.addNode("ERROR", address);
+    }
+
+    @Test
+    public void getNodeIDTest_Delete() throws Exception {
+        NameServerDatabase nameServerDatabase = new NameServerDatabase();
+
+        InetAddress address1 = InetAddress.getByName("10.10.10.10");
+        InetAddress address2 = InetAddress.getByName("10.10.10.11");
+        InetAddress address3 = InetAddress.getByName("10.10.10.12");
+
+
+        nameServerDatabase.addNode(createStringWithKnownHash(10), address1);
+        nameServerDatabase.addNode(createStringWithKnownHash(32000), address2);
+        nameServerDatabase.addNode(createStringWithKnownHash(15), address3);
+
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(12)), 10);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(12)), address1);
+
+        nameServerDatabase.deleteNode(address1);
+
+        assertEquals(nameServerDatabase.getClosestNodeID(createStringWithKnownHash(12)), 15);
+        assertEquals(nameServerDatabase.getClosestNodeIP(createStringWithKnownHash(12)), address3);
+    }
 
     /**
      * creates random string whos hash after NameToHash.convert is the asked number.
@@ -89,7 +169,7 @@ public class NameServerDatabaseTests {
     private String createStringWithKnownHash(int wantedHash){
         Random random = new Random();
         while (true){
-            String candidate = random.ints(48, 122).limit(30).collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString();
+            String candidate = random.ints(0, 1000).limit(30).collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString();
             if (NameToHash.convert(candidate) == wantedHash){
                 return candidate;
             }


### PR DESCRIPTION
I made "addNode" more robust in NameServerDatabase.java. Now nodes that happen to have the same Hashcode don't overide each other. Added a way to delete nodes. Made a lot of tests for these. Also notices a small mistake in Mapping.java When casting from a double to an int everything after the comma gets dropped (so 1.9 becomes 1) This made it nearly impossible to get 32768 out of NameToHash.convert, 32767 was the highest I could get. fixed it by adding Math.round before casting to int (still needs to vast because it returns a long)